### PR TITLE
Fix out of bound exception in SelectableTextView

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Below is the minimum API version for scripting to be compatible with the engine'
 
 | Engine version  |                                        API version                                        |
 |:---------------:|:-----------------------------------------------------------------------------------------:|
-| __1.8 - 1.8.6__ | [__1.8__](https://central.sonatype.com/artifact/io.github.baole444/thecellbeyond-api/1.8) |
+| __1.8 - 1.8.7__ | [__1.8__](https://central.sonatype.com/artifact/io.github.baole444/thecellbeyond-api/1.8) |
 |       1.7       |   [1.7](https://central.sonatype.com/artifact/io.github.baole444/thecellbeyond-api/1.7)   |
 |   1.6 - 1.6.1   |   [1.6](https://central.sonatype.com/artifact/io.github.baole444/thecellbeyond-api/1.6)   |
 |   1.5 - 1.5.2   |   [1.5](https://central.sonatype.com/artifact/io.github.baole444/thecellbeyond-api/1.5)   |

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ imgui_macos = natives-macos
 
 # Project
 project_group = io.github.baole444
-TCB_version = 1.8.6
+TCB_version = 1.8.7
 TCB_API_version = 1.8
 
 # ANTLR4 (script language lexer/parser generation)

--- a/src/main/java/editor/widgets/SelectableTextView.java
+++ b/src/main/java/editor/widgets/SelectableTextView.java
@@ -461,7 +461,7 @@ public final class SelectableTextView {
 
     private static int segmentIndexOf(RowLayout layout, int charOffset) {
         for (int i = 0; i < layout.segments.length; i++) {
-            if (charOffset <= layout.segments[i][i]) return i;
+            if (charOffset <= layout.segments[i][1]) return i;
         }
         return layout.segments.length - 1;
     }


### PR DESCRIPTION
Fix a typo in segmentIndexOf method of SelectableTextView causing index out of bound when selecting a long log section and shrink the window width, leading to increase in line span count.